### PR TITLE
Fix failing pytest tests

### DIFF
--- a/rob/tests/test_cli.py
+++ b/rob/tests/test_cli.py
@@ -2,7 +2,7 @@ import importlib
 
 import pytest
 
-cli_mod = importlib.import_module("robo.rob.utilities.cli")
+cli_mod = importlib.import_module("rob.utilities.cli")
 
 
 @pytest.fixture(autouse=True)

--- a/rob/tests/test_homework_cli.py
+++ b/rob/tests/test_homework_cli.py
@@ -9,7 +9,7 @@ def test_homework_module_exposes_app(monkeypatch):
 	survey_stub = ModuleType("survey")
 	monkeypatch.setitem(sys.modules, "survey", survey_stub)
 
-	mod = importlib.import_module("robo.rob.homework")
+	mod = importlib.import_module("rob.homework")
 	assert hasattr(mod, "app")
 
 
@@ -18,7 +18,7 @@ def test_help_shows_user_option(monkeypatch):
 	survey_stub = ModuleType("survey")
 	monkeypatch.setitem(sys.modules, "survey", survey_stub)
 
-	mod = importlib.import_module("robo.rob.homework")
+	mod = importlib.import_module("rob.homework")
 
 	from typer.testing import CliRunner
 
@@ -41,7 +41,7 @@ def test_algebra_list_weights_smoke(monkeypatch):
 	survey_stub = ModuleType("survey")
 	monkeypatch.setitem(sys.modules, "survey", survey_stub)
 
-	mod = importlib.import_module("robo.rob.homework")
+	mod = importlib.import_module("rob.homework")
 
 	import os
 	from pathlib import Path
@@ -77,7 +77,7 @@ def test_weights_persist_for_user(monkeypatch):
 	survey_stub = ModuleType("survey")
 	monkeypatch.setitem(sys.modules, "survey", survey_stub)
 
-	mod = importlib.import_module("robo.rob.homework")
+	mod = importlib.import_module("rob.homework")
 
 	import os
 	from pathlib import Path
@@ -117,7 +117,7 @@ def test_render_produces_tex(monkeypatch):
 	survey_stub = ModuleType("survey")
 	monkeypatch.setitem(sys.modules, "survey", survey_stub)
 
-	mod = importlib.import_module("robo.rob.homework")
+	mod = importlib.import_module("rob.homework")
 
 	import os
 	from pathlib import Path
@@ -162,7 +162,7 @@ def test_config_algebra_updates_weights(monkeypatch):
 	survey_stub = ModuleType("survey")
 	monkeypatch.setitem(sys.modules, "survey", survey_stub)
 
-	mod = importlib.import_module("robo.rob.homework")
+	mod = importlib.import_module("rob.homework")
 
 	import os
 	from pathlib import Path
@@ -182,7 +182,7 @@ def test_config_algebra_updates_weights(monkeypatch):
 	def fake_form_from_dict(form, *args, **kwargs):  # type: ignore
 		return {k: 111 for k in form.keys()}
 
-	monkeypatch.setattr("robo.rob.homework.query.form_from_dict", fake_form_from_dict)
+	monkeypatch.setattr("rob.homework.query.form_from_dict", fake_form_from_dict)
 
 	with runner.isolated_filesystem():
 		tmp_dir = Path(os.getcwd()) / "_appdata"

--- a/rob/utilities/cli.py
+++ b/rob/utilities/cli.py
@@ -150,19 +150,15 @@ def _parse_options(raw_args: list[str]) -> Dict[str, str | bool]:
 
 _REGISTERED_COMMANDS: Dict[str, Callable[[], None]] = {}
 OPTIONS: Dict[str, Any] = _CONFIG.get("options", {})
-_PASSED_OPTIONS: Dict[str, Any] = _parse_options(sys.argv[1:])
+_PASSED_OPTIONS: Dict[str, Any] = {}
 
 
 def _update_options():
     for option, value in _PASSED_OPTIONS.items():
         if option in OPTIONS:
             OPTIONS[option] = value
-        else:
-            rich.print(f"[red]Unknown option: {option}[/red]\n")
-            _print_usage()
-            sys.exit(1)
+        # Don't error on unknown options here - they might be function parameters
 
-    OPTIONS.update(_PASSED_OPTIONS)
     _DEBUG = OPTIONS.get("debug", False)
 
 
@@ -288,11 +284,13 @@ def main(passed_args: list[str] | None = None) -> None:
     If passed_args is not provided, sys.argv[1:] is used.
     """
 
-    global OPTIONS, _DEBUG
-    _update_options()
-
+    global OPTIONS, _DEBUG, _PASSED_OPTIONS
+    
     if passed_args is None:
         passed_args = sys.argv[1:]
+    
+    _PASSED_OPTIONS = _parse_options(passed_args)
+    _update_options()
 
     passed_command = []
     for token in passed_args:


### PR DESCRIPTION
Fixes failing pytest tests by correcting module import paths and refactoring CLI option parsing.

The CLI's `_PASSED_OPTIONS` was initialized at module import time, capturing pytest arguments, and `_update_options` incorrectly validated all options as global, rejecting valid function parameters. The fix moves `_PASSED_OPTIONS` initialization to `main()` and modifies `_update_options()` to only process global options.

---
<a href="https://cursor.com/background-agent?bcId=bc-39e1d8af-faa6-4d3f-b204-2fe37e777217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39e1d8af-faa6-4d3f-b204-2fe37e777217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

