### PR TITLE
Fix and refactor pytest tests

### DIFF
--- a/rob/tests/test_cli.py
+++ b/rob/tests/test_cli.py
@@ -2,7 +2,7 @@ import importlib
 
 import pytest
 
-cli_mod = importlib.import_module("robo.rob.utilities.cli")
+cli_mod = importlib.import_module("rob.utilities.cli")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Correct `test_cli.py` import path to match the current `rob.utilities.cli` module location.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e87d5a3-0dd1-4500-b40b-6c7adf51d88a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e87d5a3-0dd1-4500-b40b-6c7adf51d88a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

